### PR TITLE
Segregate even and odd nodes in a Link List

### DIFF
--- a/DAY29/Segregate even and odd nodes in a Link List
+++ b/DAY29/Segregate even and odd nodes in a Link List
@@ -1,0 +1,25 @@
+class Solution{
+public:
+    Node* divide(int N, Node *head)
+    {
+        // code here
+        auto prev = new Node(-1), head2 = new Node(-1); 
+        prev->next = head, head = prev;
+        auto cur = prev->next, cur2 = head2;
+        while (cur) 
+        {
+            if (cur->data & 1) 
+            {
+                prev->next = cur->next;
+                cur2->next = cur, cur2 = cur;
+            }
+            else prev = cur;
+            cur = cur->next;
+        }
+        cur2->next = nullptr;
+        prev->next = head2->next;
+        return head->next;
+    }
+};
+
+#driver code


### PR DESCRIPTION
Given a link list of size N, modify the list such that all the even numbers appear before all the odd numbers in the modified list. The order of appearance of numbers within each segregation should be same as that in the original list.

NOTE: Don't create a new linked list, instead rearrange the provided one.